### PR TITLE
Remove tracker.archlinux.org

### DIFF
--- a/mktorrent-archlinux
+++ b/mktorrent-archlinux
@@ -23,7 +23,6 @@ httpmirrorlist=$(curl https://www.archlinux.org/mirrorlist/all/http/ \
 echo 'Building torrent...'
 mktorrent \
 	-l 19 \
-	-a 'http://tracker.archlinux.org:6969/announce' \
 	-c "Arch Linux ${archver} (www.archlinux.org)" \
 	${httpmirrorlist} \
 	"${isofile}"


### PR DESCRIPTION
Arch Linux will stop running it's hefurd instance on
tracker.archlinux.org as our torrent has webseeds and these days DHT
work pretty well for obtaining the iso. This reduces maintenace costs on
our infrastructure.

Signed-off-by: Jelle van der Waa <jelle@archlinux.org>